### PR TITLE
Modernize web schedule UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,23 +29,47 @@
       gap: 10px;
     }
     select, button {
-      padding: 8px;
+      padding: 8px 12px;
       font-size: 16px;
+      border-radius: 6px;
+    }
+    button {
+      background: #006400;
+      color: #fff;
+      border: none;
+      cursor: pointer;
+    }
+    button:hover {
+      background: #008040;
     }
     .card {
-      border: 1px solid #ccc;
-      padding: 12px;
-      margin-bottom: 10px;
-      border-radius: 6px;
-      background: #f9f9f9;
+      border: 1px solid transparent;
+      padding: 16px;
+      margin-bottom: 15px;
+      border-radius: 12px;
+      background: rgba(255,255,255,0.8);
+      border-image: linear-gradient(45deg, #006400, #00a86b) 1;
+      box-shadow: 0 2px 5px rgba(0,0,0,0.1);
     }
     .team {
-      font-size: 20px;
+      font-size: 22px;
       font-weight: 600;
+      color: #006400;
     }
-    .time, .location, .duty {
+    .time {
       font-size: 14px;
       margin-top: 4px;
+      color: #1565c0;
+    }
+    .location {
+      font-size: 14px;
+      margin-top: 4px;
+      color: #ff7043;
+    }
+    .duty {
+      font-size: 14px;
+      margin-top: 4px;
+      color: #8e24aa;
     }
     .popup, .overlay {
       position: fixed;
@@ -63,12 +87,14 @@
       z-index: 101;
     }
     .popup-content {
-      background: white;
+      background: rgba(255,255,255,0.95);
       padding: 20px;
-      border-radius: 10px;
+      border-radius: 12px;
       max-width: 400px;
       width: 100%;
-      box-shadow: 0 2px 10px rgba(0,0,0,0.2);
+      box-shadow: 0 2px 15px rgba(0,0,0,0.2);
+      border: 1px solid transparent;
+      border-image: linear-gradient(45deg, #006400, #00a86b) 1;
     }
     .popup-content input[type="tel"],
     .popup-content input[type="text"] {
@@ -95,6 +121,7 @@
     }
     .popup-buttons button {
       margin-left: 10px;
+      padding: 8px 12px;
     }
     .label-column {
       width: 80px;
@@ -114,6 +141,7 @@
       padding: 2px 5px;
       border-radius: 4px;
       margin: 0 2px;
+      background: #e8f5e9;
     }
     .loading-overlay {
       position: fixed;
@@ -259,9 +287,9 @@
           const teamHTML = `<span class="team-color">${match.team}</span> vs <span class="team-color">${match.opponent}</span>`;
           card.innerHTML = `
             <div class="team">${teamHTML}</div>
-            <div class="time">Time: ${match.time}</div>
-            <div class="location">Court: ${match.location}</div>
-            <div class="duty">Duty: ${match.dutyTeam}</div>
+            <div class="time">⏰ Time: ${match.time}</div>
+            <div class="location">🏟️ Court: ${match.location}</div>
+            <div class="duty">🛠️ Duty: ${match.dutyTeam}</div>
           `;
 
           if (match.allowResult) {


### PR DESCRIPTION
## Summary
- restyle site with clean white look and green gradient borders
- highlight match teams and color code time, court and duty text
- style buttons and popups consistently
- prepend emojis to time, court and duty labels

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842b44d6e6483209fb5e43b01c12cc2