### PR TITLE
Remove results link

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,7 +186,6 @@
     <button id='liveTab' onclick="showTab('live')">Live results</button>
   </div>
   <div id="scheduleSection">
-  <button style="margin-bottom: 10px;" onclick="location.href='https://docs.google.com/spreadsheets/d/e/2PACX-1vTga3n1OyQpIdKMYzJ5bnUqg2iuYLaQ4pLYdgwgbkXex8_aG7cPZLHs_XfKMn8-k_kuG6o4kXWf89Z0/pubhtml'">View Results</button>
   <div class="filters">
     <select id="teamFilter"></select>
     <select id="divisionFilter"></select>


### PR DESCRIPTION
## Summary
- remove the obsolete **View Results** button

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685f537ccb088320825e7e1f66d5e60b