### PR TITLE
Add JSON-driven live results

### DIFF
--- a/content/results.json
+++ b/content/results.json
@@ -1,0 +1,24 @@
+{
+  "divisions": {
+    "Division A": {
+      "standings": [
+        {"team": "Team Alpha", "wins": 2, "losses": 1, "draws": 0, "setsWon": 7, "setsLost": 3, "pointsWon": 210, "pointsLost": 190},
+        {"team": "Team Beta", "wins": 1, "losses": 2, "draws": 0, "setsWon": 5, "setsLost": 6, "pointsWon": 195, "pointsLost": 205}
+      ],
+      "matches": [
+        "Team Alpha def. Team Beta 2-1 (25-20, 23-25, 15-10)",
+        "Team Beta lost to Team Alpha 0-2 (18-25, 21-25)"
+      ]
+    },
+    "Division B": {
+      "standings": [
+        {"team": "Team Gamma", "wins": 3, "losses": 0, "draws": 0, "setsWon": 6, "setsLost": 1, "pointsWon": 180, "pointsLost": 150},
+        {"team": "Team Delta", "wins": 0, "losses": 3, "draws": 0, "setsWon": 1, "setsLost": 6, "pointsWon": 150, "pointsLost": 180}
+      ],
+      "matches": [
+        "Team Gamma def. Team Delta 2-0 (25-18, 25-22)",
+        "Team Gamma def. Team Delta 2-1 (22-25, 25-19, 15-12)"
+      ]
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -175,6 +175,27 @@
     .tab-bar button.active {
       background: #008040;
     }
+    .division-tabs {
+      margin-bottom: 15px;
+      display: flex;
+      gap: 10px;
+    }
+    .division-tabs button.active {
+      background: #008040;
+    }
+    .ranking-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-bottom: 10px;
+    }
+    .ranking-table th, .ranking-table td {
+      border: 1px solid #ccc;
+      padding: 6px;
+      text-align: center;
+    }
+    .match-result {
+      margin-bottom: 6px;
+    }
 
   </style>
 </head>
@@ -196,7 +217,8 @@
   <div id="results"></div>
   </div>
   <div id="liveResultsSection" style="display:none;">
-    <iframe src="https://docs.google.com/spreadsheets/d/e/2PACX-1vTga3n1OyQpIdKMYzJ5bnUqg2iuYLaQ4pLYdgwgbkXex8_aG7cPZLHs_XfKMn8-k_kuG6o4kXWf89Z0/pubhtml" style="width:100%;height:600px;border:0;"></iframe>
+    <div id="divisionTabs" class="division-tabs"></div>
+    <div id="divisionContent"></div>
   </div>
 
   <script>
@@ -242,6 +264,59 @@
       populateFilters();
       document.getElementById("dateFilter").value = defaultDate;
       filterResults();
+    }
+
+    let liveResults = {};
+    async function fetchResults() {
+      const res = await fetch('content/results.json', { cache: 'no-store' });
+      liveResults = await res.json();
+      const tabs = document.getElementById('divisionTabs');
+      tabs.innerHTML = '';
+      const divisions = Object.keys(liveResults.divisions || {});
+      if (!divisions.length) return;
+      divisions.forEach((div, idx) => {
+        const btn = document.createElement('button');
+        btn.textContent = div;
+        btn.dataset.division = div;
+        if (idx === 0) btn.classList.add('active');
+        btn.onclick = () => showDivision(div);
+        tabs.appendChild(btn);
+      });
+      showDivision(divisions[0]);
+    }
+
+    function showDivision(div) {
+      const data = (liveResults.divisions || {})[div];
+      const container = document.getElementById('divisionContent');
+      if (!data) { container.innerHTML = ''; return; }
+
+      let html = '<table class="ranking-table"><thead><tr>' +
+        '<th>#</th><th>Team</th><th>W</th><th>L</th><th>D</th>' +
+        '<th>SW</th><th>SL</th><th>Set%</th>' +
+        '<th>PW</th><th>PL</th><th>Pts%</th>' +
+        '</tr></thead><tbody>';
+      data.standings.forEach((row, i) => {
+        const setPct = row.setsWon + row.setsLost > 0 ?
+          (row.setsWon / (row.setsWon + row.setsLost) * 100).toFixed(1) : '0';
+        const scorePct = row.pointsWon + row.pointsLost > 0 ?
+          (row.pointsWon / (row.pointsWon + row.pointsLost) * 100).toFixed(1) : '0';
+        html += `<tr><td>${i + 1}</td><td>${row.team}</td><td>${row.wins}</td>` +
+          `<td>${row.losses}</td><td>${row.draws}</td>` +
+          `<td>${row.setsWon}</td><td>${row.setsLost}</td><td>${setPct}%</td>` +
+          `<td>${row.pointsWon}</td><td>${row.pointsLost}</td><td>${scorePct}%</td></tr>`;
+      });
+      html += '</tbody></table>';
+
+      html += '<div class="match-results">';
+      data.matches.forEach(m => { html += `<div class="match-result">${m}</div>`; });
+      html += '</div>';
+
+      container.innerHTML = html;
+
+      const tabs = document.getElementById('divisionTabs').children;
+      for (const btn of tabs) btn.classList.remove('active');
+      const activeBtn = document.querySelector(`#divisionTabs button[data-division="${div}"]`);
+      if (activeBtn) activeBtn.classList.add('active');
     }
 
     function populateFilters() {
@@ -502,7 +577,11 @@
       filterResults();
     });
     document.getElementById("dateFilter").addEventListener("change", filterResults);
-    window.addEventListener("DOMContentLoaded", () => { showTab("schedule"); fetchSchedule(); });
+    window.addEventListener("DOMContentLoaded", () => {
+      showTab("schedule");
+      fetchSchedule();
+      fetchResults();
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove embedded Google Sheet for live results
- fetch new `content/results.json` to display standings and results per division
- show live results in tabs by division

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f583217b88320a9b945126ed513d4