### PR TITLE
Use Google sheet for live results

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,10 @@ Then open `http://localhost:8000` in your browser to view `index.html`.
 
 The CMS commits the new file under `content/matches/` so the schedule can be updated automatically.
 
+## Live Results
+
+Live standings and score submissions are also driven by the same Google Sheets
+document used for the schedule. The site calls a Google Apps Script (`apiUrl` in
+`index.html`) to fetch the latest results and to record score updates. This
+means no manual updates to `content/results.json` are required.
+

--- a/index.html
+++ b/index.html
@@ -279,7 +279,7 @@
 
     let liveResults = {};
     async function fetchResults() {
-      const res = await fetch('content/results.json', { cache: 'no-store' });
+      const res = await fetch(`${apiUrl}?action=getResults`, { cache: 'no-store' });
       liveResults = await res.json();
       const tabs = document.getElementById('divisionTabs');
       tabs.innerHTML = '';


### PR DESCRIPTION
## Summary
- fetch live results via Google Apps Script instead of local JSON
- document that results are managed with the same Google sheet

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685f791cb7f48320947f08d71c523d40