### PR TITLE
Fix live results when Google sheet lacks standings

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,6 +253,56 @@
       return (name || "").trim().toLowerCase();
     }
 
+    function computeStandings(schedule) {
+      const divStats = {};
+      for (const date in schedule || {}) {
+        (schedule[date] || []).forEach(match => {
+          const { division, team, opponent, scores = {} } = match || {};
+          const a = scores.a || [];
+          const b = scores.b || [];
+          if (!a.length && !b.length) return;
+          const div = division || 'Unknown';
+          divStats[div] = divStats[div] || {};
+          const tA = divStats[div][team] ||
+            { wins: 0, losses: 0, draws: 0, setsWon: 0, setsLost: 0, pointsWon: 0, pointsLost: 0 };
+          const tB = divStats[div][opponent] ||
+            { wins: 0, losses: 0, draws: 0, setsWon: 0, setsLost: 0, pointsWon: 0, pointsLost: 0 };
+          let swA = 0, swB = 0;
+          const len = Math.max(a.length, b.length);
+          for (let i = 0; i < len; i++) {
+            const sa = parseInt(a[i]);
+            const sb = parseInt(b[i]);
+            if (!isNaN(sa)) {
+              tA.pointsWon += sa;
+              tB.pointsLost += sa;
+            }
+            if (!isNaN(sb)) {
+              tA.pointsLost += sb;
+              tB.pointsWon += sb;
+            }
+            if (!isNaN(sa) && !isNaN(sb)) {
+              if (sa > sb) swA++; else if (sb > sa) swB++;
+            }
+          }
+          tA.setsWon += swA; tA.setsLost += swB;
+          tB.setsWon += swB; tB.setsLost += swA;
+          if (swA > swB) { tA.wins++; tB.losses++; }
+          else if (swB > swA) { tB.wins++; tA.losses++; }
+          else { tA.draws++; tB.draws++; }
+          divStats[div][team] = tA;
+          divStats[div][opponent] = tB;
+        });
+      }
+      const result = {};
+      for (const div in divStats) {
+        const teams = divStats[div];
+        const arr = Object.keys(teams).map(t => ({ team: t, ...teams[t] }));
+        arr.sort((a, b) => b.wins - a.wins || b.setsWon - a.setsWon || b.pointsWon - a.pointsWon);
+        result[div] = { standings: arr };
+      }
+      return result;
+    }
+
     async function fetchSchedule() {
       const res = await fetch(apiUrl, { cache: "no-store" });
       const json = await res.json();
@@ -281,6 +331,12 @@
     async function fetchResults() {
       const res = await fetch(`${apiUrl}?action=getResults`, { cache: 'no-store' });
       liveResults = await res.json();
+      if (!liveResults.schedule) {
+        liveResults = { schedule: liveResults };
+      }
+      if (!liveResults.divisions) {
+        liveResults.divisions = computeStandings(liveResults.schedule);
+      }
       const tabs = document.getElementById('divisionTabs');
       tabs.innerHTML = '';
       const divisions = Object.keys(liveResults.divisions || {});


### PR DESCRIPTION
## Summary
- compute standings from match scores when the JSON doesn't include a `divisions` block
- gracefully handle a JSON response that only contains schedule data

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685f812481e88320bbc4d6a7713bd9fa