### PR TITLE
Add loading overlay on initial load

### DIFF
--- a/index.html
+++ b/index.html
@@ -771,9 +771,10 @@
     });
     document.getElementById("dateFilter").addEventListener("change", filterResults);
     window.addEventListener("DOMContentLoaded", async () => {
+      showLoading("Data retrieving");
       showTab("schedule");
-      await fetchSchedule();
-      await fetchResults();
+      await Promise.all([fetchSchedule(), fetchResults()]);
+      hideLoading();
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- show a `Data retrieving` overlay while schedule and results are loading
- fetch schedule and live results concurrently for faster load

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685fd7a5da188320bf3188af37e74849