### PR TITLE
Add third set tiebreak rule

### DIFF
--- a/index.html
+++ b/index.html
@@ -347,7 +347,14 @@
               tB.pointsWon += sb;
             }
             if (!isNaN(sa) && !isNaN(sb)) {
-              if (sa > sb) swA++; else if (sb > sa) swB++;
+              let count = true;
+              if (i === 2) {
+                const diff = Math.abs(sa - sb);
+                if (!((sa >= 8 || sb >= 8) && diff >= 2)) count = false;
+              }
+              if (count) {
+                if (sa > sb) swA++; else if (sb > sa) swB++;
+              }
             }
           }
           tA.setsWon += swA; tA.setsLost += swB;
@@ -491,7 +498,14 @@
             const sa = aScores[i];
             const sb = bScores[i];
             if (sa !== undefined && sb !== undefined) {
-              if (parseInt(sa) > parseInt(sb)) swA++; else if (parseInt(sb) > parseInt(sa)) swB++;
+              let count = true;
+              if (i === 2) {
+                const diff = Math.abs(sa - sb);
+                if (!((sa >= 8 || sb >= 8) && diff >= 2)) count = false;
+              }
+              if (count) {
+                if (parseInt(sa) > parseInt(sb)) swA++; else if (parseInt(sb) > parseInt(sa)) swB++;
+              }
             }
             if (sa !== undefined || sb !== undefined) {
               setText.push(`${sa ?? '-'}-${sb ?? '-'}`);


### PR DESCRIPTION
## Summary
- implement rule that a third set only counts toward standings when the winning team scores 8 or more and leads by two points
- apply the same logic when displaying match results

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_685fe272fbdc8320b644defb65ba0882