### PR TITLE
Add match date to schedule cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,11 @@
       margin-top: 4px;
       color: #8e24aa;
     }
+    .match-date {
+      font-size: 14px;
+      margin-top: 4px;
+      color: #006400;
+    }
     .popup, .overlay {
       position: fixed;
       top: 0; left: 0;
@@ -623,6 +628,7 @@
           card.innerHTML = `
             <div class="team">${teamHTML}</div>
             <div class="division" style="color:${getDivisionColor(match.division)}">${match.division}</div>
+            <div class="match-date">📅 Date: ${d}</div>
             <div class="time">⏰ Time: ${match.time}</div>
             <div class="location">🏟️ Court: ${match.location}</div>
             <div class="duty">🛠️ Duty: ${match.dutyTeam}</div>


### PR DESCRIPTION
## Summary
- display the match date on each schedule card
- style new match-date element

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6860c320bea88320ac322dedaabfda6c