### PR TITLE
Add live results auto refresh note

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,6 +219,11 @@
       padding: 6px;
       text-align: center;
     }
+    .auto-renew-note {
+      font-size: 14px;
+      margin-bottom: 5px;
+      color: #666;
+    }
     .match-day {
       margin-bottom: 15px;
     }
@@ -486,7 +491,8 @@
       const container = document.getElementById('divisionContent');
       if (!data) { container.innerHTML = ''; return; }
 
-      let html = '<table class="ranking-table"><thead><tr>' +
+      let html = '<div class="auto-renew-note">Table auto renew every 30 sec</div>' +
+        '<table class="ranking-table"><thead><tr>' +
         '<th>#</th><th>Team</th><th>W</th><th>L</th><th>D</th>' +
         '<th>SW</th><th>SL</th><th>Set%</th>' +
         '<th>PW</th><th>PL</th><th>Pts%</th>' +


### PR DESCRIPTION
## Summary
- show a small note about automatic table refresh in Live results

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6860c71c80ec8320840b07accee8ea33