### PR TITLE
Show per-set scores under team names

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,6 +238,21 @@
     .match-result {
       margin-bottom: 6px;
     }
+    .match-header {
+      display: grid;
+      grid-template-columns: 1fr auto 1fr;
+      align-items: center;
+    }
+    .set-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 4px;
+    }
+    .set-table td {
+      width: 50%;
+      padding: 2px 0;
+      text-align: center;
+    }
 
   </style>
 </head>
@@ -526,7 +541,6 @@
           const bScores = (match.scores && match.scores.b) || [];
           const len = Math.max(aScores.length, bScores.length);
           let swA = 0, swB = 0;
-          const setText = [];
           for (let i = 0; i < len; i++) {
             const sa = aScores[i];
             const sb = bScores[i];
@@ -538,15 +552,28 @@
                 if (parseInt(sa) > parseInt(sb)) swA++; else if (parseInt(sb) > parseInt(sa)) swB++;
               }
             }
-            if (sa !== undefined || sb !== undefined) {
-              setText.push(`${sa ?? '-'}-${sb ?? '-'}`);
-            }
+            // collect set rows later
           }
         const keyA = normalizeName(match.team);
         const keyB = normalizeName(match.opponent);
         const colorA = getTeamColor(match.team);
         const colorB = getTeamColor(match.opponent);
-        html += `<div class="match-result"><span class="team-color" data-team="${keyA}" style="color:${colorA}">${match.team}</span> ${swA}-${swB} <span class="team-color" data-team="${keyB}" style="color:${colorB}">${match.opponent}</span> (${setText.join(', ')})</div>`;
+
+        const rows = [];
+        for (let i = 0; i < len; i++) {
+          const sa = aScores[i] ?? '-';
+          const sb = bScores[i] ?? '-';
+          if (sa !== '-' || sb !== '-') {
+            rows.push(`<tr><td>${sa}</td><td>${sb}</td></tr>`);
+          }
+        }
+
+        html += `<div class="match-result">` +
+          `<div class="match-header"><span class="team-color" data-team="${keyA}" style="color:${colorA}">${match.team}</span>` +
+          ` <span>${swA}-${swB}</span> ` +
+          `<span class="team-color" data-team="${keyB}" style="color:${colorB}">${match.opponent}</span></div>` +
+          `<table class="set-table">${rows.join('')}</table>` +
+          `</div>`;
         });
         html += '</div>';
       }


### PR DESCRIPTION
## Summary
- show per-set scores under team names in live results
- style match header and set table for alignment

## Testing
- `python3 -m http.server`

------
https://chatgpt.com/codex/tasks/task_e_6862543c4de88320b61f6d042155a7b9