### PR TITLE
Update live results layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,6 +251,7 @@
       font-size: 20px;
       font-weight: bold;
       color: #0d47a1;
+      white-space: nowrap;
     }
     .set-table {
       width: 100%;
@@ -258,9 +259,19 @@
       margin-top: 4px;
     }
     .set-table td {
-      width: 50%;
-      padding: 2px 0;
-      text-align: center;
+      padding: 2px 4px;
+    }
+    .set-label {
+      width: 40%;
+      font-size: 14px;
+      text-align: right;
+      color: #555;
+    }
+    .set-score {
+      width: 60%;
+      font-size: 16px;
+      font-weight: 600;
+      text-align: left;
     }
 
   </style>
@@ -568,13 +579,15 @@
         const colorA = getTeamColor(match.team);
         const colorB = getTeamColor(match.opponent);
 
+        const setLabels = ['1st Set', '2nd Set', '3rd Set', '4th Set', '5th Set'];
         const rows = [];
         for (let i = 0; i < len; i++) {
-          const sa = aScores[i] ?? '-';
-          const sb = bScores[i] ?? '-';
-          if (sa !== '-' || sb !== '-') {
-            rows.push(`<tr><td>${sa}</td><td>${sb}</td></tr>`);
-          }
+          const sa = aScores[i];
+          const sb = bScores[i];
+          if (sa === undefined && sb === undefined) continue;
+          const label = setLabels[i] || `${i + 1}th Set`;
+          const score = (sa === undefined || sb === undefined) ? '-' : `${sa}-${sb}`;
+          rows.push(`<tr><td class="set-label">${label}</td><td class="set-score">${score}</td></tr>`);
         }
 
         html += `<div class="match-result">` +


### PR DESCRIPTION
## Summary
- prevent live results set score from wrapping
- label each set and join scores with a hyphen
- style set labels and scores for clarity

## Testing
- `git ls-files '*.py'`

------
https://chatgpt.com/codex/tasks/task_e_68628932d9e08320a29b9532dd116cac