### PR TITLE
Fix live results layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,9 +250,13 @@
       justify-content: center;
       align-items: center;
       gap: 8px;
+      flex-wrap: wrap;
     }
-    .match-header .team-color {
+    .match-header .team-color,
+    .match-header .set-count {
       margin: 0 4px;
+      display: inline-flex;
+      align-items: center;
     }
     .match-header .set-count {
       font-size: 20px;
@@ -267,8 +271,9 @@
       table-layout: fixed;
     }
     .set-table th, .set-table td {
-      padding: 2px 4px;
+      padding: 1px 4px;
       text-align: center;
+      vertical-align: middle;
     }
     .set-table th.set-num {
       text-align: left;


### PR DESCRIPTION
## Summary
- adjust match header to wrap team names and vertically center set counts
- center set table cells and reduce spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686291c6ad308320a99e3718c562616a