### PR TITLE
Adjust live results layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,14 +243,15 @@
       color: #006400;
     }
     .match-result {
-      margin-bottom: 6px;
+      width: 260px;
+      margin: 0 auto 6px;
     }
     .match-header {
       display: flex;
       justify-content: center;
       align-items: center;
       gap: 8px;
-      flex-wrap: wrap;
+      flex-wrap: nowrap;
     }
     .match-header .team-color,
     .match-header .set-count {
@@ -276,7 +277,7 @@
       vertical-align: middle;
     }
     .set-table th.set-num {
-      text-align: left;
+      text-align: center;
       font-size: 14px;
       color: #555;
     }


### PR DESCRIPTION
## Summary
- keep teams on the same line in live results
- center the set headers and scores
- fix match result width so set count stays centered

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68631b7553f88320b7b517013d9da4e7