### PR TITLE
Enhance live highlight style

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,8 +157,15 @@
       background: #e8f5e9;
     }
     .team-entry { cursor: pointer; }
-    .team-color.highlight { background: #fff59d; }
-    .ranking-table tr.highlight td { background: #fffde7; }
+    .team-color.highlight {
+      background: #fff59d;
+      outline: 2px solid #39ff14;
+      box-shadow: 0 0 6px #39ff14;
+    }
+    .ranking-table tr.highlight td {
+      background: #fffde7;
+      box-shadow: 0 0 6px #39ff14;
+    }
     .division {
       display: inline-block;
       background: #e0e0e0;


### PR DESCRIPTION
## Summary
- add glowing outline effect to highlighted team names and rows

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68633269874c83209b9531aeffaf45cb