### PR TITLE
Add printable schedule button

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ document used for the schedule. The site calls a Google Apps Script (`apiUrl` in
 `index.html`) to fetch the latest results and to record score updates. This
 means no manual updates to `content/results.json` are required.
 
+## Printing the Schedule
+
+Within the Schedule tab of `index.html`, click **Print Schedule** to open a printable view of all matches. Use your browser's print dialog to save the page as PDF or send it directly to a printer.
+

--- a/index.html
+++ b/index.html
@@ -312,6 +312,7 @@
     <select id="courtFilter"></select>
     <select id="dateFilter"></select>
     <button onclick="resetFilters()">Reset</button>
+    <button onclick="openPrintSchedule()">Print Schedule</button>
   </div>
   <div id="results"></div>
   </div>
@@ -740,13 +741,35 @@
             btn.onclick = () => promptPasscode(d, index, match.team, match.opponent);
             card.appendChild(btn);
           }
-          results.appendChild(card);
-        });
+      results.appendChild(card);
       });
-    }
+    });
+  }
 
-    function promptPasscode(date, index, team, opponent) {
-      const overlay = document.createElement("div");
+  function openPrintSchedule() {
+    const win = window.open('', '_blank');
+    if (!win) return;
+    const doc = win.document;
+    doc.write('<html><head><title>Printable Schedule</title>');
+    doc.write('<style>body{font-family:Arial,Helvetica,sans-serif;margin:20px;}table{border-collapse:collapse;width:100%;font-size:12px;}th,td{border:1px solid #333;padding:4px;text-align:left;}@page{size:A4 landscape;margin:10mm;}</style>');
+    doc.write('</head><body>');
+    doc.write('<h1>Sparrows Volleyball Schedule</h1>');
+    doc.write('<table><thead><tr><th>Date</th><th>Time</th><th>Team</th><th>Opponent</th><th>Division</th><th>Court</th><th>Duty</th></tr></thead><tbody>');
+    const dates = Object.keys(scheduleData).sort();
+    dates.forEach(d => {
+      (scheduleData[d] || []).forEach(m => {
+        if (!m) return;
+        doc.write(`<tr><td>${d}</td><td>${m.time || ''}</td><td>${m.team || ''}</td><td>${m.opponent || ''}</td><td>${m.division || ''}</td><td>${m.location || ''}</td><td>${m.dutyTeam || ''}</td></tr>`);
+      });
+    });
+    doc.write('</tbody></table>');
+    doc.write('<script>window.onload=function(){window.print();};</script>');
+    doc.write('</body></html>');
+    doc.close();
+  }
+
+  function promptPasscode(date, index, team, opponent) {
+    const overlay = document.createElement("div");
       overlay.className = "overlay";
       const popup = document.createElement("div");
       popup.className = "popup";


### PR DESCRIPTION
## Summary
- add **Print Schedule** button to index page
- implement `openPrintSchedule` function to render a printable table and call browser print
- document printing capability in README

## Testing
- `python3 -m http.server` (server started without errors)

------
https://chatgpt.com/codex/tasks/task_e_68636c81a0048320ad583d5ee3e82dc1