### PR TITLE
Fix team names clipping

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,9 +260,8 @@
     }
     .match-header .team-color {
       flex: 1;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
+      white-space: normal; /* allow team names to wrap */
+      overflow-wrap: anywhere;
     }
     .match-header .team-color:first-child {
       text-align: right;


### PR DESCRIPTION
## Summary
- allow team names in the Live results table to wrap

## Testing
- `find . -name '*.py'`

------
https://chatgpt.com/codex/tasks/task_e_68648cbcad7883209b86c0feb1d2cf63