### PR TITLE
Fix team name alignment in live results

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,14 +260,18 @@
     }
     .match-header .team-color {
       flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       white-space: normal; /* allow team names to wrap */
       overflow-wrap: anywhere;
+      text-align: center;
     }
     .match-header .team-color:first-child {
-      text-align: right;
+      text-align: center;
     }
     .match-header .team-color:last-child {
-      text-align: left;
+      text-align: center;
     }
     .match-header .set-count {
       flex: 0 0 auto;


### PR DESCRIPTION
## Summary
- center team names horizontally and vertically within their colored backgrounds on the Live results page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68649057d2488320bff939c2f26c9b0c