### PR TITLE
Update division placement in matrix table

### DIFF
--- a/index.html
+++ b/index.html
@@ -1159,11 +1159,14 @@
                 let height = 3.5; // top padding to first team name
                 ms.forEach((m, idx) => {
                   const dutyLines = doc.splitTextToSize(`Duty: ${m.dutyTeam || ''}`, data.cell.width - 4).length;
-                  // 3.5 line spacing for all text lines
-                  height += 7 + dutyLines * 3.5 + 3.5 + 4; // team+opp, duty, gap before division, division
+                  // team+opp lines + duty lines
+                  height += 7 + dutyLines * 3.5;
                   if (idx < ms.length - 1) height += 3.5; // gap between matches
                 });
-                height += 3.5; // bottom padding after last match
+                height += 3.5; // gap before divisions
+                height += ms.length * 4; // division badges height
+                if (ms.length > 1) height += (ms.length - 1) * 3.5; // gaps between division badges
+                height += 3.5; // bottom padding after divisions
                 // Row height grows with content without a predefined limit
                 data.cell.styles.minCellHeight = height;
                 data.cell.text = '';
@@ -1197,7 +1200,11 @@
                   doc.text(line, data.cell.x + 2, y);
                   y += 3.5;
                 });
-                y += 3.5; // gap before division
+                if (idx < ms.length - 1) y += 3.5; // gap between matches
+              });
+              // space before divisions
+              y += 3.5;
+              ms.forEach((m, idx) => {
                 const padding = 2;
                 const divText = m.division || '';
                 const textW = doc.getTextWidth(divText);
@@ -1208,9 +1215,10 @@
                 doc.setFontSize(7);
                 doc.setTextColor(51, 51, 51);
                 doc.text(divText, data.cell.x + 2 + padding, y + rectH - 1);
-                y += rectH + 3.5;
-                if (idx < ms.length - 1) y += 3.5; // gap between matches
+                y += rectH;
+                if (idx < ms.length - 1) y += 3.5; // gap between division labels
               });
+              y += 3.5; // bottom padding
               doc.setTextColor(0,0,0);
             }
           }


### PR DESCRIPTION
## Summary
- move each match's division label to the bottom of its cell in the matrix print view

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866190d68788320878cac3d76e8d706