### PR TITLE
Fix PDF matrix row height

### DIFF
--- a/index.html
+++ b/index.html
@@ -1129,8 +1129,8 @@
         const times = Array.from(new Set(matches.map(m => m.time))).sort();
         const courts = Array.from(new Set(matches.map(m => m.location))).sort();
 
-        // Cell height now solely depends on the number of matches in each cell
-        // instead of being dynamically limited by the available page height.
+        // Cell height is fixed to 15px for every slot in the matrix table so
+        // all rows have a consistent height regardless of their content.
 
         const body = times.map(t => {
           const row = [t];
@@ -1145,7 +1145,7 @@
           head: [["Time", ...courts]],
           body,
           margin: { top: marginTop },
-          styles: { fontSize: 9, cellPadding: 1, lineWidth: 0.1, lineColor: [0, 0, 0] },
+          styles: { fontSize: 9, cellPadding: 1, lineWidth: 0.1, lineColor: [0, 0, 0], minCellHeight: 15 },
           headStyles: { fillColor: [0, 100, 0] },
           tableLineWidth: 0.1,
           tableLineColor: [0, 0, 0],
@@ -1155,20 +1155,8 @@
                 data.cell.styles.fontSize = 11;
                 data.cell.styles.fontStyle = 'bold';
               } else if (data.column.index > 0) {
-                const ms = (data.cell.raw && data.cell.raw.matches) || [];
-                let height = 3.5; // top padding to first team name
-                ms.forEach((m, idx) => {
-                  const dutyLines = doc.splitTextToSize(`Duty: ${m.dutyTeam || ''}`, data.cell.width - 4).length;
-                  // team+opp lines + duty lines
-                  height += 7 + dutyLines * 3.5;
-                  if (idx < ms.length - 1) height += 3.5; // gap between matches
-                });
-                height += 3.5; // gap before divisions
-                height += ms.length * 4; // division badges height
-                if (ms.length > 1) height += (ms.length - 1) * 3.5; // gaps between division badges
-                height += 3.5; // bottom padding after divisions
-                // Row height grows with content without a predefined limit
-                data.cell.styles.minCellHeight = height;
+                // Fixed cell height for matrix table
+                data.cell.styles.minCellHeight = 15;
                 data.cell.text = '';
               }
             }


### PR DESCRIPTION
## Summary
- adjust matrix table generation for Print Schedule
- force all landscape matrix cells to a 15px height

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68661e2268708320b4408fa14df0aa32