### PR TITLE
Fix mobile layout of header

### DIFF
--- a/index.html
+++ b/index.html
@@ -326,6 +326,13 @@
       font-weight: 600;
     }
 
+    @media (max-width: 600px) {
+      .site-header {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+    }
+
   </style>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.28/jspdf.plugin.autotable.min.js"></script>


### PR DESCRIPTION
## Summary
- ensure logos and header stack vertically on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686bb1e1477483209ee55ff2abc0b21c