### PR TITLE
Hide combine button on single division

### DIFF
--- a/index.html
+++ b/index.html
@@ -603,6 +603,8 @@
       tabs.innerHTML = '';
       const divisions = Object.keys(liveResults.divisions || {});
       if (!divisions.length) return;
+      const combineBtn = document.getElementById('combineViewBtn');
+      combineBtn.style.display = divisions.length > 1 ? 'inline-block' : 'none';
       divisions.forEach((div, idx) => {
         const btn = document.createElement('button');
         btn.textContent = div;


### PR DESCRIPTION
## Summary
- hide the **Combine Divisions Table View** button when live results only contain one division

## Testing
- `python3 -m py_compile $(git ls-files '*.py')` *(fails: the following arguments are required: filenames)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686faab3870c8320ac08ca78079545d1