### PR TITLE
Fix combine view visibility logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -651,7 +651,8 @@
       const divisions = Object.keys(liveResults.divisions || {});
       if (!divisions.length) return;
       const combineBtn = document.getElementById('combineViewBtn');
-      combineBtn.style.display = divisions.length > 1 ? 'inline-block' : 'none';
+      const nonFinalDivs = divisions.filter(d => !/finals/i.test(d));
+      combineBtn.style.display = nonFinalDivs.length > 1 ? 'inline-block' : 'none';
       divisions.forEach((div, idx) => {
         const btn = document.createElement('button');
         btn.textContent = div;


### PR DESCRIPTION
## Summary
- update logic to ignore finals when showing the combine division table button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686fb35f3d6083208575658a5f8ff30d