### PR TITLE
Update pickleball ranking control to toggle switch UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -529,8 +529,48 @@
       flex-wrap: wrap;
     }
     .ranking-switch-label {
-      font-size: 13px;
+      font-size: 14px;
+      font-weight: 600;
       color: #0f7a67;
+    }
+    .ranking-switch-control {
+      position: relative;
+      width: 48px;
+      height: 26px;
+      display: inline-block;
+    }
+    .ranking-switch-control input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+      position: absolute;
+    }
+    .ranking-switch-slider {
+      position: absolute;
+      inset: 0;
+      border-radius: 999px;
+      background: linear-gradient(120deg, #0c4f8f, #08386a);
+      cursor: pointer;
+      transition: background 0.2s ease;
+      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+    }
+    .ranking-switch-slider::before {
+      content: "";
+      position: absolute;
+      left: 3px;
+      top: 3px;
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      background: #fffaf2;
+      transition: transform 0.2s ease;
+      box-shadow: 0 2px 5px rgba(0, 0, 0, 0.25);
+    }
+    .ranking-switch-control input:checked + .ranking-switch-slider {
+      background: linear-gradient(120deg, #12c4a0, #0f9a7f);
+    }
+    .ranking-switch-control input:checked + .ranking-switch-slider::before {
+      transform: translateX(22px);
     }
     .finals-toggle-wrap {
       margin-bottom: 10px;
@@ -2363,11 +2403,11 @@
       if (canShowPlayerRanking) {
         const checkedAttr = showPlayerRanking ? 'checked' : '';
         html += `<div class="ranking-switch-wrap">
-          <label>
+          <label class="ranking-switch-control" for="pickleballRankingSwitch">
             <input type="checkbox" id="pickleballRankingSwitch" ${checkedAttr}>
-            Show participant ranking
+            <span class="ranking-switch-slider"></span>
           </label>
-          <span class="ranking-switch-label">Toggle between team ranking and participant ranking.</span>
+          <span class="ranking-switch-label">Show player ranking</span>
         </div>`;
       }
       html += '<div class="auto-renew-note">Table auto refresh every 15 sec</div>' +


### PR DESCRIPTION
### Motivation
- For Pickleball tournaments on the Live Results page, replace the existing participant-ranking checkbox with a toggle switch so users can clearly switch between team and player ranking, update the label text, and remove the explanatory helper text.

### Description
- Add CSS for a styled toggle switch including `.ranking-switch-control` and `.ranking-switch-slider`, and increase the ranking label font-size and weight in `index.html`.
- Replace the checkbox markup in the combined-division ranking UI with the new switch markup while keeping the underlying input id `pickleballRankingSwitch` and checked-state logic intact.
- Change the adjacent text from `Show participant ranking` to `Show player ranking` and remove the helper line `Toggle between team ranking and participant ranking.`.
- Preserve existing behavior so Off shows team ranking and On shows player (participant) ranking.

### Testing
- Ran `rg -n "Show participant ranking|Toggle between team ranking and participant ranking|Show player ranking|ranking-switch-control|ranking-switch-slider" index.html` which confirmed the old strings were removed and the new switch and label are present.
- Ran `git status --short` and committed the change which completed successfully, confirming the file update was recorded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3649c960083208929cdfa32f67bb2)