### PR TITLE
Support 5-set result entry when tournament numberOfSets equals 5

### DIFF
--- a/index.html
+++ b/index.html
@@ -1015,7 +1015,9 @@
     }
 
     function getScoreInputSetCount() {
-      return usePickleballRules() ? 4 : 3;
+      if (usePickleballRules()) return 4;
+      const configuredSetCount = Number(tournamentMetaCache[currentTournament]?.numberOfSets);
+      return configuredSetCount === 5 ? 5 : 3;
     }
 
     function getSetWinnerDelta(saRaw, sbRaw, division = "") {
@@ -1151,16 +1153,17 @@
 
     function normalizeTournamentEntry(entry) {
       if (typeof entry === "string") {
-        return { name: entry, subtitle: "", drawLink: "" };
+        return { name: entry, subtitle: "", drawLink: "", numberOfSets: "" };
       }
       if (entry && typeof entry === "object") {
         return {
           name: entry.name || entry.tournament || "",
           subtitle: entry.webSubtitleLine1 || entry.subtitle || entry.webSubtitle || "",
-          drawLink: typeof entry.drawLink === "string" ? entry.drawLink.trim() : ""
+          drawLink: typeof entry.drawLink === "string" ? entry.drawLink.trim() : "",
+          numberOfSets: entry.numberOfSets ?? ""
         };
       }
-      return { name: "", subtitle: "", drawLink: "" };
+      return { name: "", subtitle: "", drawLink: "", numberOfSets: "" };
     }
 
     const TOURNAMENT_LIST_CACHE_KEY = "sparrows:tournaments:list";
@@ -1228,7 +1231,8 @@
       const json = await res.json();
       const subtitle = (json.webSubtitleLine1 || "").trim();
       const drawLink = typeof json.drawLink === "string" ? json.drawLink.trim() : "";
-      tournamentMetaCache[name] = { subtitle, drawLink };
+      const numberOfSets = json.numberOfSets ?? "";
+      tournamentMetaCache[name] = { subtitle, drawLink, numberOfSets };
       return tournamentMetaCache[name];
     }
 
@@ -1265,7 +1269,7 @@
 
       function renderTournaments(normalized) {
         listEl.innerHTML = "";
-        normalized.forEach(({ name, subtitle, drawLink }) => {
+        normalized.forEach(({ name, subtitle, drawLink, numberOfSets }) => {
           const card = document.createElement("div");
           card.className = "tournament-card";
           card.innerHTML = `
@@ -1281,7 +1285,7 @@
           const subtitleEl = card.querySelector(".tournament-card-subtitle");
           if (subtitle) {
             subtitleEl.textContent = subtitle;
-            tournamentMetaCache[name] = { subtitle, drawLink };
+            tournamentMetaCache[name] = { subtitle, drawLink, numberOfSets };
           } else {
             subtitleEl.textContent = " ";
             fetchTournamentMeta(name).then(meta => {
@@ -2685,7 +2689,7 @@
 
       const setLabels = usePickleballRules()
         ? ["Singles A", "Singles B", "Doubles G1", "Doubles G2"]
-        : ["1st Set", "2nd Set", "3rd Set"];
+        : getSetLabels().slice(0, getScoreInputSetCount());
       const headerRow = `
         <div class="set-row">
           <span class="label-column"></span>


### PR DESCRIPTION
### Motivation
- Allow non-pickleball tournaments to enter 5-set match results when the tournament metadata sets `numberOfSets = 5`, while preserving existing 3-set default behavior otherwise. 
- Keep Pickleball mode unchanged (it still uses 4 inputs and the existing rules). 

### Description
- Read and cache `numberOfSets` from tournament list payload and the per-tournament metadata fetch into `tournamentMetaCache` (via `normalizeTournamentEntry` and `fetchTournamentMeta`).
- Update `getScoreInputSetCount()` so that it returns `4` for pickleball, `5` when `tournamentMetaCache[currentTournament].numberOfSets === 5`, and `3` otherwise.
- Render the Enter Scores popup set rows dynamically by using `getSetLabels().slice(0, getScoreInputSetCount())` so 4th/5th set rows appear only when configured.
- Submission already iterates `for (let i = 1; i <= setCount; i++)` using `getScoreInputSetCount()`, so `a4/b4` and `a5/b5` are appended and will be included in the existing Live Results calculations without additional changes.

### Testing
- Ran repository/file discovery with `rg --files | head -n 200` to confirm files present and locate `index.html`.
- Performed targeted code searches with `rg -n "function getScoreInputSetCount|getScoreInputSetCount\(|numberOfSets" index.html content/results.json` to verify updated logic and references. 
- Inspected updated `index.html` regions with `nl`/`sed` to confirm `normalizeTournamentEntry`, `fetchTournamentMeta`, `getScoreInputSetCount`, and Enter Scores popup lines were changed as intended; all inspections matched expected edits. 
- Verified that the submit path reads `getScoreInputSetCount()` to append `aN/bN` parameters so extra sets will be posted; inspection succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f968815aec832098325e45cd871f3e)